### PR TITLE
Adding top margin

### DIFF
--- a/stylesheets/mockup.css
+++ b/stylesheets/mockup.css
@@ -44,6 +44,7 @@ and open the template in the editor.
     height: 8in;
     background-color: #fff;
     overflow: hidden;
+    margin-top: .5in;
 }
 
 #site-header, #site-footer {


### PR DESCRIPTION
Currently when printing, there is not enough margin at the top of pages so printing is often cut off.  This fix will cause an extra page at the end (not sure exactly why) but makes this more usable.